### PR TITLE
FLUID-5167: dependencies handling is more rohbust

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,18 @@ module.exports = function(grunt) {
           exclude: ["moduleA"]
         },
         src: "<%= modulefiles.all.src %>"
+      },
+      nonArrayDependencies: {
+        options: {
+          include: ["moduleC"]
+        },
+        src: "<%= modulefiles.all.src %>"
+      },
+      noDependencies: {
+        options: {
+          include: ["moduleD"]
+        },
+        src: "<%= modulefiles.all.src %>"
       }
     },
 
@@ -83,7 +95,9 @@ module.exports = function(grunt) {
       exclude: "<%= modulefiles.exclude.output %>",
       includeAndExclude: "<%= modulefiles.includeAndExclude.output %>",
       includeArray: "<%= modulefiles.includeArray.output %>",
-      excludeArray: "<%= modulefiles.excludeArray.output %>"
+      excludeArray: "<%= modulefiles.excludeArray.output %>",
+      nonArrayDependencies: "<%= modulefiles.nonArrayDependencies.output %>",
+      noDependencies: "<%= modulefiles.noDependencies.output %>"
     },
 
     // Unit tests.

--- a/tasks/modulefiles.js
+++ b/tasks/modulefiles.js
@@ -24,9 +24,13 @@ module.exports = function(grunt) {
    * @return {Array} The accumulated file paths, in the order that they are depended on.
    */
   var getFilesImp = function (moduleDependencies, module, exclusions) {
-      var dependencies = grunt.util._.difference(module.dependencies, exclusions);
+      var dependencies = module.dependencies || [];
+      if (typeof dependencies === "string") {
+        dependencies = dependencies.split(",");
+      }
+      var includedDependencies = grunt.util._.difference(dependencies, exclusions);
       var paths = [];
-      grunt.util._.forEach(dependencies, function (dependency) {
+      grunt.util._.forEach(includedDependencies, function (dependency) {
           paths = grunt.util._.union(paths, getFilesImp(moduleDependencies, moduleDependencies[dependency], exclusions));
       });
       paths = grunt.util._.union(paths, module.files);

--- a/test/expected/all
+++ b/test/expected/all
@@ -1,1 +1,1 @@
-moduleA-file1.js,moduleA-file2.js,moduleB-file1.js,moduleB-file2.js
+moduleA-file1.js,moduleA-file2.js,moduleB-file1.js,moduleB-file2.js,moduleC-file1.js,moduleC-file2.js,moduleD-file1.js,moduleD-file2.js

--- a/test/expected/exclude
+++ b/test/expected/exclude
@@ -1,1 +1,1 @@
-moduleB-file1.js,moduleB-file2.js
+moduleB-file1.js,moduleB-file2.js,moduleC-file1.js,moduleC-file2.js,moduleD-file1.js,moduleD-file2.js

--- a/test/expected/excludeArray
+++ b/test/expected/excludeArray
@@ -1,1 +1,1 @@
-moduleB-file1.js,moduleB-file2.js
+moduleB-file1.js,moduleB-file2.js,moduleC-file1.js,moduleC-file2.js,moduleD-file1.js,moduleD-file2.js

--- a/test/expected/noDependencies
+++ b/test/expected/noDependencies
@@ -1,0 +1,1 @@
+moduleD-file1.js,moduleD-file2.js

--- a/test/expected/nonArrayDependencies
+++ b/test/expected/nonArrayDependencies
@@ -1,0 +1,1 @@
+moduleA-file1.js,moduleA-file2.js,moduleC-file1.js,moduleC-file2.js

--- a/test/fixtures/moduleCDependencies.json
+++ b/test/fixtures/moduleCDependencies.json
@@ -1,0 +1,6 @@
+{
+    "moduleC": {
+        "files": ["moduleC-file1.js", "moduleC-file2.js"],
+        "dependencies": "moduleA"
+    }
+}

--- a/test/fixtures/moduleDDependencies.json
+++ b/test/fixtures/moduleDDependencies.json
@@ -1,0 +1,5 @@
+{
+    "moduleD": {
+        "files": ["moduleD-file1.js", "moduleD-file2.js"]
+    }
+}

--- a/test/modulefiles_test.js
+++ b/test/modulefiles_test.js
@@ -69,5 +69,11 @@ exports.modulefiles = {
   },
   excludeArray: function(test) {
     assertPackageFiles(test, "excludeArray");
+  },
+  nonArrayDependencies: function(test) {
+    assertPackageFiles(test, "nonArrayDependencies");
+  },
+  noDependencies: function(test) {
+    assertPackageFiles(test, "noDependencies");
   }
 };


### PR DESCRIPTION
Now the dependencies section in a json dependency file can be specified as a string, array, or be left off completely.

http://issues.fluidproject.org/browse/FLUID-5167
